### PR TITLE
more useful error messages

### DIFF
--- a/mango.R
+++ b/mango.R
@@ -106,6 +106,21 @@ if (opt["bowtiepath"] != "NULL")
   bowtiepath = opt["bowtiepath"]
 }
 
+if (identical(bedtoolspath, "notfound"))
+{
+  stop("bedtools not found in path.")
+}  
+
+if (identical(macs2path, "notfound"))
+{
+  stop("macs2 not found in path.")
+} 
+
+if (identical(bowtiepath, "notfound"))
+{
+  stop("bowtie2 not found in path.")
+} 
+
 # get software versions
 bedtoolsversion = system(paste(bedtoolspath,"--version"),intern=TRUE)[1]
 macs2version    = system(paste(macs2path,"--version 2>&1"),intern=TRUE)[1]

--- a/mango.R
+++ b/mango.R
@@ -118,7 +118,7 @@ if (identical(macs2path, "notfound"))
 
 if (identical(bowtiepath, "notfound"))
 {
-  stop("bowtie2 not found in path.")
+  stop("bowtie not found in path.")
 } 
 
 # get software versions


### PR DESCRIPTION
This will automatically notify people if the required software is not found in the path. Otherwise, it prints something like:

> sh: notfound: command not found
> Error in system(paste(bowtiepath, "--version"), intern = TRUE) : 
>   error in running command
